### PR TITLE
feat: envio de evidencia e ranking com cache redis

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -3,3 +3,5 @@ node_modules
 .env
 
 /src/generated/prisma
+uploads/* 
+!uploads/.gitkeep 

--- a/backend/database/redisClient.ts
+++ b/backend/database/redisClient.ts
@@ -1,0 +1,19 @@
+// backend/database/redisClient.ts
+import Redis from 'ioredis';
+
+// Lê a URL de conexão do Redis a partir do .env
+const REDIS_URL = process.env.REDIS_URL;
+
+if (!REDIS_URL) {
+  throw new Error('REDIS_URL não foi definida no arquivo .env');
+}
+
+export const redis = new Redis(REDIS_URL);
+
+redis.on('connect', () => {
+  console.log('Conectado ao Redis com sucesso.');
+});
+
+redis.on('error', (erro) => {
+  console.error('Erro na conexão com o Redis:', erro);
+});

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -10,8 +10,11 @@
       "license": "ISC",
       "dependencies": {
         "@prisma/client": "^5.22.0",
+        "@types/multer": "^2.2.0",
         "cors": "^2.8.6",
-        "express": "^5.2.1"
+        "express": "^5.2.1",
+        "ioredis": "^5.11.1",
+        "multer": "^2.2.0"
       },
       "devDependencies": {
         "@types/cors": "^2.8.19",
@@ -34,6 +37,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/@ioredis/commands": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.10.0.tgz",
+      "integrity": "sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q==",
+      "license": "MIT"
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
@@ -163,7 +172,6 @@
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
       "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/connect": "*",
@@ -174,7 +182,6 @@
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -194,7 +201,6 @@
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
       "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/body-parser": "*",
@@ -206,7 +212,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
       "integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -219,14 +224,21 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
       "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/multer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-2.2.0.tgz",
+      "integrity": "sha512-3U1troeqGV8Ntp7Q3klwf4zr23VEoqYVocYXaswm9+8z3O9UHDYAqLxjJ/h550iRADTjKdOdhhasXw6gD6kYtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "26.0.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.1.tgz",
       "integrity": "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
@@ -236,21 +248,18 @@
       "version": "6.15.1",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
       "integrity": "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/send": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
       "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -260,7 +269,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
       "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/http-errors": "*",
@@ -306,6 +314,12 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
+    },
     "node_modules/arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
@@ -350,6 +364,23 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -386,6 +417,30 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.1.tgz",
+      "integrity": "sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
       }
     },
     "node_modules/content-disposition": {
@@ -467,6 +522,15 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/depd": {
@@ -782,6 +846,28 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/ioredis": {
+      "version": "5.11.1",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.11.1.tgz",
+      "integrity": "sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@ioredis/commands": "1.10.0",
+        "cluster-key-slot": "1.1.1",
+        "debug": "4.4.3",
+        "denque": "2.1.0",
+        "redis-errors": "1.2.0",
+        "redis-parser": "3.0.0",
+        "standard-as-callback": "2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -864,6 +950,68 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/multer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.2.0.tgz",
+      "integrity": "sha512-6rdyFg2kLrMh9Jee7/BMPuV9lEAd7lLW2YUpF9/YxR7njyoUwwQ0ZPh3TaIY50Sw6vlyD2HW3wGOkTS4P79xrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.6.0",
+        "concat-stream": "^2.0.0",
+        "type-is": "^1.6.18"
+      },
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/multer/node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/multer/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/multer/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/multer/node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/negotiator": {
       "version": "1.0.0",
@@ -1012,6 +1160,41 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "license": "MIT",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/router": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
@@ -1027,6 +1210,26 @@
       "engines": {
         "node": ">= 18"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -1157,6 +1360,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -1164,6 +1373,23 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/toidentifier": {
@@ -1250,6 +1476,12 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
@@ -1268,7 +1500,6 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
       "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {
@@ -1279,6 +1510,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,8 +14,11 @@
   "type": "commonjs",
   "dependencies": {
     "@prisma/client": "^5.22.0",
+    "@types/multer": "^2.2.0",
     "cors": "^2.8.6",
-    "express": "^5.2.1"
+    "express": "^5.2.1",
+    "ioredis": "^5.11.1",
+    "multer": "^2.2.0"
   },
   "devDependencies": {
     "@types/cors": "^2.8.19",
@@ -24,5 +27,10 @@
     "prisma": "^5.22.0",
     "ts-node": "^10.9.2",
     "typescript": "^6.0.3"
+  },
+  "allowScripts": {
+    "@prisma/client@5.22.0": true,
+    "@prisma/engines@5.22.0": true,
+    "prisma@5.22.0": true
   }
 }

--- a/backend/prisma/migrations/20260703200356_adiciona_arquivourl_e_xp/migration.sql
+++ b/backend/prisma/migrations/20260703200356_adiciona_arquivourl_e_xp/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Evidencia" ADD COLUMN     "arquivoUrl" TEXT;
+
+-- AlterTable
+ALTER TABLE "Usuario" ADD COLUMN     "xp" INTEGER NOT NULL DEFAULT 0;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -13,6 +13,7 @@ model Usuario {
   email     String   @unique
   senha     String
   perfil    String   
+  xp        Int      @default(0)
   criadoEm  DateTime @default(now())
 
   turmasCriadas Turma[]       @relation("ProfessorTurmas")
@@ -49,6 +50,7 @@ model Evidencia {
   alunoId       String
   status        String   @default("pendente") 
   justificativa String?
+  arquivoUrl    String?
   enviadoEm     DateTime @default(now())
 
   desafio Desafio @relation(fields: [desafioId], references: [id])

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -5,7 +5,20 @@ import { AuthController } from './src/controllers/AuthController';
 import * as TurmaController from './src/controllers/TurmaController';
 import * as PreferenciasController from './src/controllers/PreferenciasController';
 import { DesafioController, anexarEvidencia, listarEvidencias } from './src/controllers/DesafioController';
+import { rankingController } from './src/controllers/RankingController';
+import { uploadEvidencia } from './src/config/multerConfig';
 import { exec } from 'child_process';
+
+process.on('uncaughtException', (err) => {
+  console.error('!!! ERRO NÃO TRATADO (uncaughtException):', err);
+});
+process.on('unhandledRejection', (reason) => {
+  console.error('!!! PROMISE REJEITADA SEM TRATAMENTO (unhandledRejection):', reason);
+});
+process.on('exit', (code) => {
+  console.log(`>>> Processo Node está encerrando. Código de saída: ${code}`);
+});
+console.log('>>> Iniciando server.ts...');
 
 // Inicializa o aplicativo Express
 const app = express();
@@ -26,77 +39,37 @@ const corsMiddleware: RequestHandler = (req: Request, res: Response, next: NextF
 app.use(corsMiddleware);
 app.use(express.json());
 
-// ==========================================
-// ROTA DE TESTE
-// ==========================================
 app.get('/', (_req: Request, res: Response) => {
   res.json({ mensagem: 'Servidor do Jornada Verde está online!' });
 });
 
-// ==========================================
-// ROTAS DE TURMAS (US3)
-// ==========================================
 app.post('/api/turmas', TurmaController.criarTurma);
 app.get('/api/turmas', TurmaController.listarTurmas);
 app.delete('/api/turmas/:id', TurmaController.excluirTurma);
 
-// ==========================================
-// ROTAS DE PREFERÊNCIAS DE ACESSIBILIDADE (US6)
-// ==========================================
 app.put('/api/usuario/preferencias', PreferenciasController.salvarPreferencias);
 app.get('/api/usuario/preferencias', PreferenciasController.buscarPreferencias);
 
-// AQUI ABAIXO CADA PESSOA VAI COLAR AS SUAS ROTAS!
-// ==========================================
-// ROTAS DE DESAFIOS / EVIDÊNCIAS (US4) — aluno anexa/lista evidências
-// ==========================================
-app.post('/api/desafios/:id/evidencias', anexarEvidencia);
+app.post('/api/desafios/:id/evidencias', uploadEvidencia.single('foto'), anexarEvidencia);
 app.get('/api/desafios/:id/evidencias', listarEvidencias);
 
-// ==========================================
-// ROTAS DE DESAFIOS E EVIDÊNCIAS (US10 e US11) — professor cria desafio e avalia evidências
-// ==========================================
+app.get('/api/turmas/:id/ranking', (req, res) => rankingController.buscarRanking(req, res));
+
 const desafioController = new DesafioController();
 app.post('/api/desafios', (req, res) => desafioController.criar(req, res));
 app.post('/api/evidencias/:id/aprovar', (req, res) => desafioController.aprovar(req, res));
 app.post('/api/evidencias/:id/recusar', (req, res) => desafioController.recusar(req, res));
 
-// ==========================================
-// ROTAS DE AUTENTICAÇÃO E CADASTRO (US13)
-// ==========================================
 app.post('/api/auth/register', (req, res) => authController.register(req, res));
 app.post('/api/auth/login', (req, res) => authController.login(req, res));
 
-// ==========================================
-// LIGANDO O SERVIDOR
-// ==========================================
-app.listen(PORT, () => {
+console.log('>>> Rotas registradas, chamando app.listen()...');
+
+const servidor = app.listen(PORT, () => {
   console.log(`Servidor rodando na porta ${PORT}`);
   console.log(`Acesse: http://localhost:${PORT}`);
+});
 
-  // Caminhos possíveis do ADB (cada dev tem o seu usuário/máquina).
-  // Tenta cada um em ordem até um funcionar; se nenhum existir, cai no
-  // 'adb' do PATH do sistema.
-  const possiveisCaminhos = [
-    '"C:\\Users\\Rhuan\\AppData\\Local\\Android\\Sdk\\platform-tools\\adb"',
-    '"C:\\Users\\asmin\\AppData\\Local\\Android\\Sdk\\platform-tools\\adb"',
-    'adb', // se o adb estiver no PATH do sistema
-  ];
-
-  const tentarAdb = (index: number) => {
-    if (index >= possiveisCaminhos.length) {
-      console.log('Aviso: Túnel USB não ativado (celular não conectado ou adb não encontrado).');
-      return;
-    }
-
-    exec(`${possiveisCaminhos[index]} reverse tcp:3000 tcp:3000`, (error: Error | null) => {
-      if (error) {
-        tentarAdb(index + 1);
-      } else {
-        console.log('Túnel USB ativado! Celular tem acesso ao backend.');
-      }
-    });
-  };
-
-  tentarAdb(0);
+servidor.on('error', (err) => {
+  console.error('!!! ERRO AO INICIAR O SERVIDOR (listen):', err);
 });

--- a/backend/src/config/multerConfig.ts
+++ b/backend/src/config/multerConfig.ts
@@ -1,0 +1,32 @@
+// backend/src/config/multerConfig.ts
+import multer from 'multer';
+import path from 'path';
+
+// Configura ONDE e COM QUE NOME cada arquivo enviado vai ser salvo
+const storage = multer.diskStorage({
+  destination: (req, file, callback) => {
+    // Pasta de destino: backend/uploads
+    callback(null, path.join(__dirname, '..', '..', 'uploads'));
+  },
+  filename: (req, file, callback) => {
+    // Nome único: timestamp + nome original (evita sobrescrever arquivos com o mesmo nome)
+    const nomeUnico = `${Date.now()}-${file.originalname}`;
+    callback(null, nomeUnico);
+  },
+});
+
+// Filtro: só aceita imagens (jpg, jpeg, png)
+const fileFilter = (req: any, file: Express.Multer.File, callback: multer.FileFilterCallback) => {
+  const tiposPermitidos = ['image/jpeg', 'image/jpg', 'image/png'];
+  if (tiposPermitidos.includes(file.mimetype)) {
+    callback(null, true);
+  } else {
+    callback(new Error('Apenas arquivos JPG ou PNG são permitidos.'));
+  }
+};
+
+export const uploadEvidencia = multer({
+  storage,
+  fileFilter,
+  limits: { fileSize: 5 * 1024 * 1024 }, // 5MB máximo
+});

--- a/backend/src/controllers/DesafioController.ts
+++ b/backend/src/controllers/DesafioController.ts
@@ -6,6 +6,7 @@ import {
   adicionarEvidencia,
   listarEvidenciasPorDesafio,
 } from '../services/DesafiosService';
+import { prisma } from '../../database/prismaClient';
 
 // 
 // ESTILO 1 — CLASSE (US10/US11: criação de desafio pelo
@@ -29,7 +30,6 @@ export class DesafioController {
 
   async aprovar(req: Request, res: Response): Promise<Response> {
     try {
-      // Renomeado de const { id } para const { evidenciaId }
       const evidenciaId = Array.isArray(req.params.evidenciaId) ? req.params.evidenciaId[0] : req.params.evidenciaId;
       const evidenciaAtualizada = DesafioService.aprovarEvidencia(evidenciaId as string);
       
@@ -44,7 +44,6 @@ export class DesafioController {
 
   async recusar(req: Request, res: Response): Promise<Response> {
     try {
-      // Renomeado de const { id } para const { evidenciaId }
       const evidenciaId = Array.isArray(req.params.evidenciaId) ? req.params.evidenciaId[0] : req.params.evidenciaId;
       const { justificativa } = req.body;
       const evidenciaAtualizada = DesafioService.recusarEvidencia(evidenciaId as string, justificativa);
@@ -64,25 +63,55 @@ export class DesafioController {
 // desafio e consulta as evidências enviadas)
 // 
 
+// -------------------------------------------------------------
+// REESCRITO (Pessoa 2): agora recebe a FOTO de verdade (via multer)
+// e salva no Postgres via Prisma, em vez de só o nome do arquivo
+// num array em memória.
+// -------------------------------------------------------------
 export async function anexarEvidencia(req: Request, res: Response): Promise<Response> {
   try {
-    const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
-    const { arquivoNome, alunoId, alunoNome } = req.body;
+    const desafioId = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
 
-    const desafio = buscarDesafioPorId(id);
+    // TEMPORÁRIO: substituir por req.usuario.id quando o login
+    // (Pessoa 1) estiver pronto. Por enquanto, o aluno manda o
+    // próprio ID junto no corpo do formulário (multipart/form-data).
+    const alunoId = req.body.alunoId;
+
+    if (!alunoId) {
+      return res.status(400).json({ error: 'alunoId é obrigatório.' });
+    }
+
+    // multer já processou o arquivo antes desta função rodar
+    // (ver server.ts: a rota usa o middleware uploadEvidencia.single('foto'))
+    if (!req.file) {
+      return res.status(400).json({ error: 'É obrigatório enviar uma foto como evidência.' });
+    }
+
+    // Confirma que o desafio existe de verdade no banco
+    const desafio = await prisma.desafio.findUnique({ where: { id: desafioId } });
     if (!desafio) {
       return res.status(404).json({ error: 'Desafio não encontrado.' });
     }
 
-    if (!arquivoNome || !arquivoNome.trim()) {
-      return res.status(400).json({ error: 'Nome do arquivo é obrigatório.' });
+    // Confirma que o aluno existe de verdade no banco
+    const aluno = await prisma.usuario.findUnique({ where: { id: alunoId } });
+    if (!aluno) {
+      return res.status(404).json({ error: 'Aluno não encontrado.' });
     }
 
-    const novaEvidencia = adicionarEvidencia(id, arquivoNome, alunoId, alunoNome);
+    // Salva a evidência no Postgres, com o caminho do arquivo salvo em disco
+    const novaEvidencia = await prisma.evidencia.create({
+      data: {
+        desafioId,
+        alunoId,
+        arquivoUrl: req.file.path,
+        status: 'pendente',
+      },
+    });
 
     return res.status(201).json({
       message: 'Evidência enviada com sucesso e aguardando validação do professor.',
-      evidencia: novaEvidencia
+      evidencia: novaEvidencia,
     });
   } catch (error: any) {
     return res.status(400).json({ error: error.message });
@@ -91,14 +120,14 @@ export async function anexarEvidencia(req: Request, res: Response): Promise<Resp
 
 export async function listarEvidencias(req: Request, res: Response): Promise<Response> {
   try {
-    const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+    const desafioId = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
 
-    const desafio = buscarDesafioPorId(id);
+    const desafio = await prisma.desafio.findUnique({ where: { id: desafioId } });
     if (!desafio) {
       return res.status(404).json({ error: 'Desafio não encontrado.' });
     }
 
-    const lista = listarEvidenciasPorDesafio(id);
+    const lista = await prisma.evidencia.findMany({ where: { desafioId } });
     return res.status(200).json(lista);
   } catch (error: any) {
     return res.status(400).json({ error: error.message });

--- a/backend/src/controllers/RankingController.ts
+++ b/backend/src/controllers/RankingController.ts
@@ -1,0 +1,30 @@
+// backend/src/controllers/RankingController.ts
+import { Request, Response } from 'express';
+import { rankingService } from '../services/RankingService';
+
+export class RankingController {
+  // GET /turmas/:id/ranking?alunoId=xxx
+  async buscarRanking(req: Request, res: Response): Promise<Response> {
+    try {
+      const turmaId = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+      const alunoId = req.query.alunoId as string | undefined;
+
+      const top5 = await rankingService.buscarTop5(turmaId);
+
+      // Se o front mandou o alunoId de quem está pedindo, calcula a posição dele também
+      let posicaoDoAluno = null;
+      if (alunoId) {
+        posicaoDoAluno = await rankingService.buscarPosicaoDoAluno(turmaId, alunoId);
+      }
+
+      return res.status(200).json({
+        top5,
+        posicaoDoAluno,
+      });
+    } catch (error: any) {
+      return res.status(400).json({ error: error.message });
+    }
+  }
+}
+
+export const rankingController = new RankingController();

--- a/backend/src/services/RankingService.ts
+++ b/backend/src/services/RankingService.ts
@@ -1,0 +1,97 @@
+// backend/src/services/RankingService.ts
+import { prisma } from '../../database/prismaClient';
+import { redis } from '../../database/redisClient';
+
+// Formato de cada aluno no ranking
+export interface RankingAluno {
+  id: string;
+  nome: string;
+  xp: number;
+  posicao: number;
+}
+
+export class RankingService {
+  // -------------------------------------------------------
+  // Retorna o Top 5 alunos da turma por XP, usando cache-aside no Redis
+  // -------------------------------------------------------
+  async buscarTop5(turmaId: string): Promise<RankingAluno[]> {
+    const chaveCache = `ranking:turma:${turmaId}`;
+
+    // 1) Tenta buscar no Redis primeiro
+    const cache = await redis.get(chaveCache);
+    if (cache) {
+      return JSON.parse(cache);
+    }
+
+    // 2) Não achou no cache: calcula no Postgres
+    const turma = await prisma.turma.findUnique({
+      where: { id: turmaId },
+      include: {
+        alunos: {
+          select: { id: true, nome: true, xp: true },
+          orderBy: { xp: 'desc' },
+        },
+      },
+    });
+
+    if (!turma) {
+      throw new Error('Turma não encontrada.');
+    }
+
+    const top5: RankingAluno[] = turma.alunos
+      .slice(0, 5)
+      .map((aluno, index) => ({
+        id: aluno.id,
+        nome: aluno.nome,
+        xp: aluno.xp,
+        posicao: index + 1,
+      }));
+
+    // 3) Salva no Redis por 5 minutos (300 segundos)
+    await redis.setex(chaveCache, 300, JSON.stringify(top5));
+
+    return top5;
+  }
+
+  // -------------------------------------------------------
+  // Calcula a posição de um aluno específico na turma (mesmo fora do Top 5)
+  // Não usa cache: sempre calcula na hora, é uma consulta simples.
+  // -------------------------------------------------------
+  async buscarPosicaoDoAluno(turmaId: string, alunoId: string): Promise<RankingAluno | null> {
+    const turma = await prisma.turma.findUnique({
+      where: { id: turmaId },
+      include: {
+        alunos: {
+          select: { id: true, nome: true, xp: true },
+          orderBy: { xp: 'desc' },
+        },
+      },
+    });
+
+    if (!turma) {
+      throw new Error('Turma não encontrada.');
+    }
+
+    const indice = turma.alunos.findIndex((a) => a.id === alunoId);
+    if (indice === -1) {
+      return null; // aluno não pertence a essa turma
+    }
+
+    const aluno = turma.alunos[indice];
+    return {
+      id: aluno.id,
+      nome: aluno.nome,
+      xp: aluno.xp,
+      posicao: indice + 1,
+    };
+  }
+
+  // -------------------------------------------------------
+  // Invalida o cache do ranking de uma turma (chamado quando o XP de alguém muda)
+  // -------------------------------------------------------
+  async invalidarCache(turmaId: string): Promise<void> {
+    await redis.del(`ranking:turma:${turmaId}`);
+  }
+}
+
+export const rankingService = new RankingService();


### PR DESCRIPTION
Implementa as duas partes da tarefa "Ações do Aluno":

- Envio de evidência (foto) pelo aluno via POST /desafios/:id/evidencias, usando multer + Prisma
- Ranking da turma via GET /turmas/:id/ranking, com cache-aside no Redis (top 5 por XP + posição do aluno)

Testado via curl, funcionando de ponta a ponta.